### PR TITLE
feat: implement ID obfuscation with Hashids for enhanced security

### DIFF
--- a/REST_API_DESIGN.md
+++ b/REST_API_DESIGN.md
@@ -109,7 +109,7 @@ Cada recurso incluye un array `_links` con hipervínculos relacionados:
 ```json
 {
   "user": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "id": "yYyWTE5wS6onSL4ouaAgs9MnFY2GinYa",
     "identity_number": "123456789",
     "first_name": "Juan",
     "last_name": "Pérez",
@@ -120,17 +120,17 @@ Cada recurso incluye un array `_links` con hipervínculos relacionados:
     "keycloak_user_id": "keycloak-uuid-here",
     "_links": [
       {
-        "href": "http://localhost:8080/motogo/api/v1/accounts/550e8400-e29b-41d4-a716-446655440000",
+        "href": "http://localhost:8080/motogo/api/v1/accounts/yYyWTE5wS6onSL4ouaAgs9MnFY2GinYa",
         "rel": "self",
         "method": "GET"
       },
       {
-        "href": "http://localhost:8080/motogo/api/v1/accounts/550e8400-e29b-41d4-a716-446655440000",
+        "href": "http://localhost:8080/motogo/api/v1/accounts/yYyWTE5wS6onSL4ouaAgs9MnFY2GinYa",
         "rel": "update",
         "method": "PUT"
       },
       {
-        "href": "http://localhost:8080/motogo/api/v1/accounts/550e8400-e29b-41d4-a716-446655440000",
+        "href": "http://localhost:8080/motogo/api/v1/accounts/yYyWTE5wS6onSL4ouaAgs9MnFY2GinYa",
         "rel": "delete",
         "method": "DELETE"
       },
@@ -223,7 +223,29 @@ Según las recomendaciones del profesor:
 - La autenticación se maneja con Keycloak
 - La lógica de negocio usa el ID local
 
-### 5. Servicios de Negocio
+### 5. Ofuscamiento de IDs (Seguridad)
+
+✅ **IDs Ofuscados** Los IDs internos de base de datos se ofuscan usando Hashids
+
+**Beneficios de seguridad**:
+- ❌ Los UUIDs internos NO se exponen directamente en la API
+- ✅ Previene enumeración de recursos (predictibilidad reducida)
+- ✅ IDs más cortos y amigables (10-32 caracteres)
+- ✅ Reversibles solo con el secreto correcto
+- ✅ Consistentes (mismo UUID = mismo ID ofuscado)
+
+**Ejemplo**:
+```
+UUID interno:  14c0a7bf-adef-4d20-a7ed-591ae9ac93c2
+ID ofuscado:   yYyWTE5wS6onSL4ouaAgs9MnFY2GinYa
+```
+
+**Configuración**:
+- Secret: Definido en `config/local-config.json` (cambiar en producción)
+- Longitud mínima: 10 caracteres
+- Alfabeto: Sin caracteres ambiguos (sin 0, O, I, l)
+
+### 6. Servicios de Negocio
 
 ✅ Los endpoints representan operaciones de negocio:
 - **POST /accounts** - Registrar nuevo usuario en el sistema

--- a/cmd/dependency/dependency.go
+++ b/cmd/dependency/dependency.go
@@ -8,6 +8,7 @@ import (
 	"github.com/EstebanGitPro/motogo-backend/core/ports/output"
 	"github.com/EstebanGitPro/motogo-backend/platform/identity_provider/keycloak"
 	"github.com/EstebanGitPro/motogo-backend/platform/logger"
+	"github.com/EstebanGitPro/motogo-backend/tools/idencoder"
 
 	mysql "github.com/EstebanGitPro/motogo-backend/platform/databases/mysql"
 
@@ -21,6 +22,7 @@ type Dependencies struct {
 	Interactor     *interactor.Interactor
 	Config         *config.Config
 	Logger         logger.Logger
+	IDEncoder      *idencoder.HashidsEncoder
 }
 
 func Init() (*Dependencies, error) {
@@ -59,6 +61,17 @@ func Init() (*Dependencies, error) {
 
 	interactorFacade := interactor.NewInteractor(personService, log)
 
+	// Inicializar IDEncoder
+	encoder, err := idencoder.NewHashidsEncoder(idencoder.Config{
+		Secret:    cfg.IDEncoder.Secret,
+		MinLength: cfg.IDEncoder.MinLength,
+	})
+	if err != nil {
+		log.Error("Error inicializando ID encoder", "error", err)
+		return nil, err
+	}
+	log.Success("ID Encoder inicializado correctamente")
+
 	log.Success("Dependencias inicializadas correctamente")
 
 	return &Dependencies{
@@ -68,5 +81,6 @@ func Init() (*Dependencies, error) {
 		Interactor:     interactorFacade,
 		Config:         cfg,
 		Logger:         log,
+		IDEncoder:      encoder,
 	}, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/EstebanGitPro/motogo-backend/platform/logger"
 	"github.com/EstebanGitPro/motogo-backend/tools/utils"
 )
+
+var log = logger.SlogLogger{}
+
 
 type Config struct {
 	Environment  string         `json:"environment"`
@@ -16,6 +21,12 @@ type Config struct {
 	Resend       Resend         `json:"resend"`
 	Verification Verification   `json:"verification"`
 	Keycloak     KeycloakConfig `json:"keycloak"`
+	IDEncoder    IDEncoder      `json:"id_encoder"`
+}
+
+type IDEncoder struct {
+	Secret    string `json:"secret"`
+	MinLength int    `json:"min_length"`
 }
 
 type Verification struct {
@@ -23,17 +34,17 @@ type Verification struct {
 }
 
 type Database struct {
-	Driver   string `json:"driver"`
-	Host     string `json:"host"`
-	Port     string `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Name     string `json:"name"`
-	SSL      string `json:"ssl,omitempty"`
-	MaxOpenConns int `json:"max_open_conns"`
-	MaxIdleConns int `json:"max_idle_conns"`
-	ConnMaxLifetime int `json:"conn_max_lifetime"`
-	ConnMaxIdleTime int `json:"conn_max_idle_time"`
+	Driver          string `json:"driver"`
+	Host            string `json:"host"`
+	Port            string `json:"port"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	Name            string `json:"name"`
+	SSL             string `json:"ssl,omitempty"`
+	MaxOpenConns    int    `json:"max_open_conns"`
+	MaxIdleConns    int    `json:"max_idle_conns"`
+	ConnMaxLifetime int    `json:"conn_max_lifetime"`
+	ConnMaxIdleTime int    `json:"conn_max_idle_time"`
 }
 
 type Server struct {
@@ -58,7 +69,8 @@ type KeycloakConfig struct {
 func LoadConfig() (*Config, error) {
 	root, err := utils.FindModuleRoot()
 	if err != nil {
-		return nil, fmt.Errorf("error finding module root: %w", err)
+		log.Error("error finding module root", err)
+		return nil, err
 	}
 
 	env := os.Getenv("APP_ENV")

--- a/config/local-config.json
+++ b/config/local-config.json
@@ -31,5 +31,9 @@
       },
     "verification": {
         "base_url": "http://localhost:8085"
+    },
+    "id_encoder": {
+        "secret": "motogo-secure-salt-change-in-production-2024",
+        "min_length": 36
     }
 }

--- a/core/interactor/interactor.go
+++ b/core/interactor/interactor.go
@@ -22,9 +22,7 @@ func NewInteractor(service input.Service, log logger.Logger) *Interactor {
 }
 
 func (i *Interactor) RegisterPerson(ctx context.Context, person domain.Person) (result *dto.RegistrationResult, err error) {
-	i.logger.Info("Iniciando proceso de registro",
-		"email", person.Email,
-		"role", person.Role)
+	i.logger.Info("Iniciando proceso de registro", person.ToLogger())
 
 	// PASO 1: Validaciones iniciales
 	result, err = i.service.RegisterPerson(ctx, person)
@@ -117,9 +115,9 @@ func (i *Interactor) RegisterPerson(ctx context.Context, person domain.Person) (
 	result.Person = person
 	result.Message = "Usuario registrado exitosamente"
 
+	//TODO: preguntar si dejar info en el logger success
 	i.logger.Success("Registro completado exitosamente",
-		"email", person.Email,
-		"person_id", person.ID,
+		person.ToLogger(),
 		"keycloak_user_id", keycloakUserID)
 
 	err = nil //asegurar que defer NO ejecute rollback

--- a/core/interactor/services/domain/errors.go
+++ b/core/interactor/services/domain/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrInvalidJSONFormat = errors.New("formato JSON inválido")
 	ErrInvalidRequest    = errors.New("parámetros de solicitud inválidos")
 	ErrInvalidID         = errors.New("ID no válido")
+	ErrInternalServer    = errors.New("error interno del servidor")
 )
 
 // Authorization Errors (MOD_A_*)

--- a/core/interactor/services/domain/person.go
+++ b/core/interactor/services/domain/person.go
@@ -5,21 +5,27 @@ import (
 )
 
 type Person struct {
-	ID                  string `json:"id"`
-	IdentityNumber      string `json:"identity_number"`
-	FirstName           string `json:"first_name"`
-	LastName            string `json:"last_name"`
-	SecondLastName      string `json:"second_last_name"`
-	Email               string `json:"email"`
-	PhoneNumber         string `json:"phone_number"`
-	Password            string `json:"-"`
-	Role                string `json:"role"`
-	KeycloakUserID      string `json:"keycloak_user_id"`
+	ID             string `json:"id"`
+	IdentityNumber string `json:"identity_number"`
+	FirstName      string `json:"first_name"`
+	LastName       string `json:"last_name"`
+	SecondLastName string `json:"second_last_name"`
+	Email          string `json:"email"`
+	PhoneNumber    string `json:"phone_number"`
+	Password       string `json:"-"`
+	Role           string `json:"role"`
+	KeycloakUserID string `json:"keycloak_user_id"`
 }
 
 func (u *Person) SetID() {
 	u.ID = uuid.New().String()
-} 
+}
 
-//TODO : Tolog.person
-
+// TODO : Tolog.person
+func (p *Person) ToLogger() []string {
+	return []string{
+		"id:" + p.ID,
+		"email:" + p.Email,
+		"role:" + p.Role,
+	}
+}

--- a/core/interactor/services/person_services.go
+++ b/core/interactor/services/person_services.go
@@ -51,7 +51,7 @@ func (s service) BeginTx(ctx context.Context) (output.Tx, error) {
 }
 
 func (s service) RegisterPerson(ctx context.Context, person domain.Person) (*dto.RegistrationResult, error) {
-	s.logger.Info("Iniciando validaciones de registro", "email", person.Email)
+	s.logger.Info("Iniciando validaciones de registro", person.ToLogger())
 
 	existingPerson, err := s.repository.GetPersonByEmail(ctx, person.Email)
 	if err == nil && existingPerson != nil {
@@ -59,7 +59,7 @@ func (s service) RegisterPerson(ctx context.Context, person domain.Person) (*dto
 		return nil, domain.ErrDuplicateUser
 	}
 
-	s.logger.Info("Validaciones de registro completadas", "email", person.Email)
+	s.logger.Info("Validaciones de registro completadas", person.ToLogger())
 	return &dto.RegistrationResult{
 		Person:  person,
 		Message: "Validaciones exitosas",
@@ -67,24 +67,24 @@ func (s service) RegisterPerson(ctx context.Context, person domain.Person) (*dto
 }
 
 func (s service) SavePersonToDB(ctx context.Context, tx output.Tx, person domain.Person) error {
-	s.logger.Info("Guardando persona en base de datos", "email", person.Email, "person_id", person.ID)
+	s.logger.Info("Guardando persona en base de datos", person.ToLogger())
 	err := s.repository.SavePerson(ctx, tx, person)
 	if err != nil {
-		s.logger.Error("Error guardando persona en BD", "email", person.Email, "error", err)
+		s.logger.Error("Error guardando persona en BD", person.ToLogger(), "error", err)
 		return err
 	}
-	s.logger.Success("Persona guardada en base de datos", "email", person.Email, "person_id", person.ID)
+	s.logger.Success("Persona guardada en base de datos", person.ToLogger())
 	return nil
 }
 
 func (s service) CreateUserInKeycloak(ctx context.Context, person *domain.Person) (string, error) {
-	s.logger.Info("Creando usuario en Keycloak", "email", person.Email, "person_id", person.ID)
+	s.logger.Info("Creando usuario en Keycloak", person.ToLogger())
 	userID, err := s.keycloak.CreateUser(ctx, person)
 	if err != nil {
-		s.logger.Error("Error creando usuario en Keycloak", "email", person.Email, "error", err)
+		s.logger.Error("Error creando usuario en Keycloak", person.ToLogger(), "error", err)
 		return "", err
 	}
-	s.logger.Success("Usuario creado en Keycloak", "email", person.Email, "keycloak_user_id", userID)
+	s.logger.Success("Usuario creado en Keycloak", person.ToLogger(), "keycloak_user_id", userID)
 	return userID, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
+	github.com/speps/go-hashids/v2 v2.0.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/quic-go/quic-go v0.54.0 h1:6s1YB9QotYI6Ospeiguknbp2Znb/jZYjZLRXn9kMQB
 github.com/quic-go/quic-go v0.54.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
+github.com/speps/go-hashids/v2 v2.0.1 h1:ViWOEqWES/pdOSq+C1SLVa8/Tnsd52XC34RY7lt7m4g=
+github.com/speps/go-hashids/v2 v2.0.1/go.mod h1:47LKunwvDZki/uRVD6NImtyk712yFzIs3UF3KlHohGw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -4,18 +4,21 @@ import (
 	"github.com/EstebanGitPro/motogo-backend/core/interactor"
 	"github.com/EstebanGitPro/motogo-backend/core/ports/input"
 	"github.com/EstebanGitPro/motogo-backend/platform/logger"
+	"github.com/EstebanGitPro/motogo-backend/tools/idencoder"
 )
 
 type handler struct {
 	PersonService input.Service
 	Interactor    *interactor.Interactor
 	Logger        logger.Logger
+	IDEncoder     *idencoder.HashidsEncoder
 }
 
-func New(service input.Service, interactor *interactor.Interactor, log logger.Logger) *handler {
+func New(service input.Service, interactor *interactor.Interactor, log logger.Logger, encoder *idencoder.HashidsEncoder) *handler {
 	return &handler{
 		PersonService: service,
 		Interactor:    interactor,
 		Logger:        log,
+		IDEncoder:     encoder,
 	}
 }

--- a/handlers/hateoas.go
+++ b/handlers/hateoas.go
@@ -1,5 +1,7 @@
 package handlers
 
+import "fmt"
+
 type Link struct {
 	Href   string `json:"href"`
 	Rel    string `json:"rel"`
@@ -10,27 +12,50 @@ type HATEOASResource struct {
 	Links []Link `json:"_links"`
 }
 
-func BuildAccountLinks(baseURL string, accountID string) []Link {
+// BuildResourceURL construye una URL completa para un recurso
+// Ejemplo: BuildResourceURL(baseURL, "accounts", encodedID) → "http://host/motogo/api/v1/accounts/xyz"
+func BuildResourceURL(baseURL, resource, resourceID string) string {
+	return fmt.Sprintf("%s/motogo/api/v1/%s/%s", baseURL, resource, resourceID)
+}
+
+// BuildCollectionURL construye una URL completa para una colección
+// Ejemplo: BuildCollectionURL(baseURL, "accounts") → "http://host/motogo/api/v1/accounts"
+func BuildCollectionURL(baseURL, resource string) string {
+	return fmt.Sprintf("%s/motogo/api/v1/%s", baseURL, resource)
+}
+
+// BuildResourceLinks construye links HATEOAS genéricos para un recurso
+// resource: nombre del recurso (ej: "accounts", "transactions")
+// resourceID: ID ya ofuscado del recurso
+func BuildResourceLinks(baseURL, resource, resourceID string) []Link {
+	resourceURL := BuildResourceURL(baseURL, resource, resourceID)
+	collectionURL := BuildCollectionURL(baseURL, resource)
+
 	return []Link{
 		{
-			Href:   baseURL + "/motogo/api/v1/accounts/" + accountID,
+			Href:   resourceURL,
 			Rel:    "self",
 			Method: "GET",
 		},
 		{
-			Href:   baseURL + "/motogo/api/v1/accounts/" + accountID,
+			Href:   resourceURL,
 			Rel:    "update",
 			Method: "PUT",
 		},
 		{
-			Href:   baseURL + "/motogo/api/v1/accounts/" + accountID,
+			Href:   resourceURL,
 			Rel:    "delete",
 			Method: "DELETE",
 		},
 		{
-			Href:   baseURL + "/motogo/api/v1/accounts",
+			Href:   collectionURL,
 			Rel:    "collection",
 			Method: "GET",
 		},
 	}
+}
+
+// BuildAccountLinks construye links específicos para cuentas (wrapper para compatibilidad)
+func BuildAccountLinks(baseURL string, accountID string) []Link {
+	return BuildResourceLinks(baseURL, "accounts", accountID)
 }

--- a/handlers/person.go
+++ b/handlers/person.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	domain "github.com/EstebanGitPro/motogo-backend/core/interactor/services/domain"
+	"github.com/gin-gonic/gin"
 )
 
 type PersonRequest struct {
@@ -55,4 +56,64 @@ func (p PersonRequest) ToDomain() domain.Person {
 		Password:       p.Password,
 		Role:           p.Role,
 	}
+}
+
+
+// GetBaseURL extrae la URL base de la petición (scheme + host)
+func GetBaseURL(c *gin.Context) string {
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + c.Request.Host
+}
+
+// EncodeID ofusca un UUID usando el encoder del handler
+// Retorna el ID ofuscado o un error si falla
+func (h *handler) EncodeID(uuid string) (string, error) {
+	encodedID, err := h.IDEncoder.Encode(uuid)
+	if err != nil {
+		h.Logger.Error("Error ofuscando ID",
+			"uuid", uuid,
+			"error", err)
+		return "", err
+	}
+	return encodedID, nil
+}
+
+// DecodeID desofusca un ID ofuscado a UUID usando el encoder del handler
+// Retorna el UUID o un error si falla
+func (h *handler) DecodeID(encodedID string) (string, error) {
+	uuid, err := h.IDEncoder.Decode(encodedID)
+	if err != nil {
+		h.Logger.Error("Error decodificando ID",
+			"encoded_id", encodedID,
+			"error", err)
+		return "", err
+	}
+	return uuid, nil
+}
+
+// HandleIDEncodingError maneja errores de ofuscamiento y envía respuesta apropiada
+func (h *handler) HandleIDEncodingError(c *gin.Context, uuid string, err error) {
+	h.Logger.Error("Error ofuscando ID",
+		"uuid", uuid,
+		"error", err,
+		"client_ip", c.ClientIP())
+	c.Error(domain.ErrInternalServer)
+}
+
+// HandleIDDecodingError maneja errores de desofuscamiento y envía respuesta apropiada
+func (h *handler) HandleIDDecodingError(c *gin.Context, encodedID string, err error) {
+	h.Logger.Error("Error decodificando ID",
+		"encoded_id", encodedID,
+		"error", err,
+		"client_ip", c.ClientIP())
+	c.Error(domain.ErrInvalidID)
+}
+
+// SetLocationHeader establece el Location header con la URL del recurso
+func SetLocationHeader(c *gin.Context, baseURL, resource, encodedID string) {
+	locationURL := BuildResourceURL(baseURL, resource, encodedID)
+	c.Header("Location", locationURL)
 }

--- a/handlers/person_controller.go
+++ b/handlers/person_controller.go
@@ -37,15 +37,17 @@ func (h handler) RegisterPerson() func(c *gin.Context) {
 			return
 		}
 
-		scheme := "http"
-		if c.Request.TLS != nil {
-			scheme = "https"
+		// Ofuscar el ID antes de exponerlo en la API
+		encodedID, err := h.EncodeID(result.Person.ID)
+		if err != nil {
+			h.HandleIDEncodingError(c, result.Person.ID, err)
+			return
 		}
-		baseURL := scheme + "://" + c.Request.Host
-		links := BuildAccountLinks(baseURL, result.Person.ID)
 
-		locationURL := baseURL + "/motogo/api/v1/accounts/" + result.Person.ID
-		c.Header("Location", locationURL)
+		// Construir respuesta con HATEOAS
+		baseURL := GetBaseURL(c)
+		links := BuildAccountLinks(baseURL, encodedID)
+		SetLocationHeader(c, baseURL, "accounts", encodedID)
 
 		response := RegistrationResponse{
 			Message: result.Message,
@@ -53,8 +55,8 @@ func (h handler) RegisterPerson() func(c *gin.Context) {
 		}
 
 		h.Logger.Success("Registro completado exitosamente",
-			"email", result.Person.Email,
-			"person_id", result.Person.ID,
+			result.Person.ToLogger(),
+			"encoded_id", encodedID,
 			"status", http.StatusCreated,
 			"client_ip", c.ClientIP())
 

--- a/middleware/sucsses_handler.go
+++ b/middleware/sucsses_handler.go
@@ -1,0 +1,1 @@
+package middleware

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ func routing(app *gin.Engine, dependencies *dependency.Dependencies) {
 
 	app.Use(middleware.ErrorHandler(dependencies.Logger))
 
-	handler := handlers.New(dependencies.PersonService, dependencies.Interactor, dependencies.Logger)
+	handler := handlers.New(dependencies.PersonService, dependencies.Interactor, dependencies.Logger, dependencies.IDEncoder)
 
 	validators, err := schema.NewValidator(&schema.DefaultFileReader{})
 	if err != nil {

--- a/tools/idencoder/idencoder.go
+++ b/tools/idencoder/idencoder.go
@@ -1,0 +1,145 @@
+package idencoder
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/EstebanGitPro/motogo-backend/platform/logger"
+	"github.com/google/uuid"
+	hashids "github.com/speps/go-hashids/v2"
+)
+
+var log = logger.SlogLogger{}
+
+// HashidsEncoder maneja la ofuscación y desofuscación de IDs usando Hashids
+type HashidsEncoder struct {
+	hashData *hashids.HashIDData
+
+}
+
+// Config contiene la configuración para el encoder
+type Config struct {
+	Secret    string
+	MinLength int
+}
+
+// NewHashidsEncoder crea una nueva instancia del encoder basado en Hashids
+func NewHashidsEncoder(cfg Config) (*HashidsEncoder, error) {
+	if cfg.Secret == "" {
+		return nil, fmt.Errorf("secret no puede estar vacío")
+	}
+
+	if cfg.MinLength == 36 {
+		log.Warn("MinLength es igual a 36, lo cual es el valor por defecto")
+	}
+
+	hd := hashids.NewData()
+	hd.Salt = cfg.Secret
+	hd.MinLength = cfg.MinLength
+	// Alfabeto sin caracteres ambiguos (sin 0, O, I, l)
+	hd.Alphabet = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ123456789"
+
+	return &HashidsEncoder{
+		hashData: hd,
+	}, nil
+}
+
+// Encode convierte un UUID a un ID ofuscado
+func (e *HashidsEncoder) Encode(uuidStr string) (string, error) {
+	// Validar que sea un UUID válido
+	parsedUUID, err := uuid.Parse(uuidStr)
+	if err != nil {
+		log.Error("UUID inválido", err)
+		return "", err
+	}
+
+	// Convertir UUID a slice de bytes
+	uuidBytes := parsedUUID[:]
+
+	// Convertir bytes a números (cada 2 bytes = 1 número de 16 bits)
+	numbers := make([]int, 0, 8)
+	for i := 0; i < len(uuidBytes); i += 2 {
+		num := int(uuidBytes[i])<<8 | int(uuidBytes[i+1])
+		numbers = append(numbers, num)
+	}
+
+	// Crear hashids y encodear
+	h, err := hashids.NewWithData(e.hashData)
+	if err != nil {
+		log.Error("error creando hashids", err)
+		return "", err
+	}
+
+	encoded, err := h.Encode(numbers)
+	if err != nil {
+		log.Error("error encodeando UUID", err)
+		return "", err
+	}
+
+	return encoded, nil
+}
+
+// Decode convierte un ID ofuscado de vuelta a UUID
+func (e *HashidsEncoder) Decode(encoded string) (string, error) {
+	if encoded == "" {
+		log.Error("ID ofuscado no puede estar vacío")
+		return "", errors.New("ID ofuscado no puede estar vacío")
+	}
+
+	// Crear hashids y decodear
+	h, err := hashids.NewWithData(e.hashData)
+	if err != nil {
+		log.Error("error creando hashids", err)
+		return "", err
+	}
+
+	numbers, err := h.DecodeWithError(encoded)
+	if err != nil {
+		log.Error("error decodeando ID ofuscado", err)
+		return "", err
+	}
+
+	if len(numbers) != 8 {
+		log.Error("ID ofuscado tiene formato incorrecto")
+		return "", errors.New("ID ofuscado tiene formato incorrecto")
+	}
+
+	// Convertir números de vuelta a bytes
+	uuidBytes := make([]byte, 16)
+	for i, num := range numbers {
+		uuidBytes[i*2] = byte(num >> 8)
+		uuidBytes[i*2+1] = byte(num & 0xFF)
+	}
+
+	// Crear UUID desde bytes
+	parsedUUID, err := uuid.FromBytes(uuidBytes)
+	if err != nil {
+		log.Error("error reconstruyendo UUID", err)
+		return "", err
+	}
+
+	return parsedUUID.String(), nil
+}
+
+// MustEncode es una versión que hace panic si hay error (usar solo en casos seguros)
+func (e *HashidsEncoder) MustEncode(uuidStr string) string {
+	encoded, err := e.Encode(uuidStr)
+	if err != nil {
+		log.Error("error encodeando UUID", err)
+	}
+	return encoded
+}
+
+// IsValidEncoded verifica si un string codificado es válido
+func (e *HashidsEncoder) IsValidEncoded(encoded string) bool {
+	_, err := e.Decode(encoded)
+	return err == nil
+}
+
+// IsUUID verifica si un string es un UUID válido
+func IsUUID(str string) bool {
+	str = strings.ToLower(str)
+	_, err := uuid.Parse(str)
+	return err == nil
+}

--- a/tools/idencoder/idencoder_test.go
+++ b/tools/idencoder/idencoder_test.go
@@ -1,0 +1,102 @@
+package idencoder
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestIDEncoder_EncodeDecodeUUID(t *testing.T) {
+	encoder, err := NewHashidsEncoder(Config{
+		Secret:    "test-secret-12345",
+		MinLength: 10,
+	})
+	if err != nil {
+		t.Fatalf("Error creating encoder: %v", err)
+	}
+
+	// Generar un UUID de prueba
+	testUUID := uuid.New().String()
+
+	// Encodear
+	encoded, err := encoder.Encode(testUUID)
+	if err != nil {
+		t.Fatalf("Error encoding UUID: %v", err)
+	}
+
+	// Verificar que el ID ofuscado tiene la longitud mínima
+	if len(encoded) < 10 {
+		t.Errorf("Encoded ID length is %d, expected at least 10", len(encoded))
+	}
+
+	// Decodear
+	decoded, err := encoder.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Error decoding ID: %v", err)
+	}
+
+	// Verificar que el UUID decodificado es igual al original
+	if decoded != testUUID {
+		t.Errorf("Decoded UUID %s doesn't match original %s", decoded, testUUID)
+	}
+
+	t.Logf("Original UUID: %s", testUUID)
+	t.Logf("Encoded ID: %s", encoded)
+	t.Logf("Decoded UUID: %s", decoded)
+}
+
+func TestIDEncoder_InvalidUUID(t *testing.T) {
+	encoder, err := NewHashidsEncoder(Config{
+		Secret:    "test-secret-12345",
+		MinLength: 10,
+	})
+	if err != nil {
+		t.Fatalf("Error creating encoder: %v", err)
+	}
+
+	// Intentar encodear un UUID inválido
+	_, err = encoder.Encode("not-a-valid-uuid")
+	if err == nil {
+		t.Error("Expected error for invalid UUID, got nil")
+	}
+}
+
+func TestIDEncoder_InvalidEncodedID(t *testing.T) {
+	encoder, err := NewHashidsEncoder(Config{
+		Secret:    "test-secret-12345",
+		MinLength: 10,
+	})
+	if err != nil {
+		t.Fatalf("Error creating encoder: %v", err)
+	}
+
+	// Intentar decodear un ID inválido
+	_, err = encoder.Decode("invalid-encoded-id")
+	if err == nil {
+		t.Error("Expected error for invalid encoded ID, got nil")
+	}
+}
+
+func TestIDEncoder_Consistency(t *testing.T) {
+	encoder, err := NewHashidsEncoder(Config{
+		Secret:    "test-secret-12345",
+		MinLength: 10,
+	})
+	if err != nil {
+		t.Fatalf("Error creating encoder: %v", err)
+	}
+
+	testUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+	// Encodear el mismo UUID múltiples veces
+	encoded1, _ := encoder.Encode(testUUID)
+	encoded2, _ := encoder.Encode(testUUID)
+	encoded3, _ := encoder.Encode(testUUID)
+
+	// Verificar que siempre genera el mismo ID ofuscado
+	if encoded1 != encoded2 || encoded2 != encoded3 {
+		t.Errorf("Encoding is not consistent: %s, %s, %s", encoded1, encoded2, encoded3)
+	}
+
+	t.Logf("UUID %s always encodes to: %s", testUUID, encoded1)
+}


### PR DESCRIPTION
- Added Hashids encoder to obfuscate internal UUIDs in API responses
- Configured IDEncoder in config with secret and minimum length settings
- Integrated encoder into dependency injection and handler initialization
- Added helper functions for building HATEOAS resource URLs with encoded IDs
- Updated REST API documentation to explain ID obfuscation security benefits
- Added Person.ToLogger() method for consistent structured logging