### PR TITLE
feat: Implement Change Password and Update Profile functionalities

### DIFF
--- a/core/interactor/interactor_person.go
+++ b/core/interactor/interactor_person.go
@@ -294,3 +294,98 @@ func (i *Interactor) Login(ctx context.Context, email, password string) (*dto.To
 		RefreshToken: token.RefreshToken,
 	}, nil
 }
+
+// ChangePassword allows an authenticated user to change their password (HU57)
+// Requires the current password for verification before setting a new one
+func (i *Interactor) ChangePassword(ctx context.Context, keycloakUserID, currentPassword, newPassword string) error {
+	traceID := middleware.GetTraceIDFromContext(ctx)
+	log := i.logger.WithTraceID(traceID)
+
+	log.Info(logger.LogChangePasswordStart, "keycloak_user_id", keycloakUserID)
+
+	// Delegate to service
+	err := i.service.ChangePassword(ctx, keycloakUserID, currentPassword, newPassword)
+	if err != nil {
+		switch err {
+		case domain.ErrUserNotFound:
+			log.Error(logger.LogChangePasswordUserNotFound, "error", err)
+		case domain.ErrInvalidCredentials:
+			log.Warn(logger.LogChangePasswordInvalidCurrent, "error", err)
+		case domain.ErrPasswordUpdateFailed:
+			log.Error(logger.LogChangePasswordUpdateError, "error", err)
+		case domain.ErrKeycloakUnavailable:
+			log.Error(logger.LogKeycloakUnavailable, "error", err)
+		default:
+			log.Error(logger.LogChangePasswordUpdateError, "error", err)
+		}
+		return err
+	}
+
+	log.Success(logger.LogChangePasswordSuccess, "keycloak_user_id", keycloakUserID)
+	return nil
+}
+
+// UpdateProfile updates the authenticated user's profile (HU52)
+// This method orchestrates the profile update with proper transaction management
+func (i *Interactor) UpdateProfile(ctx context.Context, person domain.Person) (*domain.Person, error) {
+	// Extract traceID from context and create logger with it
+	traceID := middleware.GetTraceIDFromContext(ctx)
+	log := i.logger.WithTraceID(traceID)
+
+	log.Info(logger.LogUpdateProfileStart, person.ToLogger())
+
+	// STEP 1: Begin transaction
+	tx, err := i.service.BeginTx(ctx)
+	if err != nil {
+		log.Error(logger.LogPersonInteractorStep2_Error, "error", err)
+		return nil, err
+	}
+
+	var profileUpdated bool
+
+	defer func() {
+		if err != nil && !profileUpdated {
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Error(logger.LogPersonInteractorRollbackDB_Error,
+					"rollback_error", rbErr,
+					"original_error", err)
+			} else {
+				log.Warn(logger.LogPersonInteractorRollbackDB_OK)
+			}
+		}
+	}()
+
+	// STEP 2: Update profile via service
+	if err = i.service.UpdatePersonProfile(ctx, tx, person); err != nil {
+		log.Error(logger.LogUpdateProfileError, "error", err, "person_id", person.ID)
+		return nil, err
+	}
+
+	// STEP 3: Commit transaction
+	if err = tx.Commit(); err != nil {
+		log.Error(logger.LogPersonInteractorCommit_Error, "error", err)
+		return nil, err
+	}
+	profileUpdated = true
+
+	log.Success(logger.LogUpdateProfileSuccess, person.ToLogger())
+	return &person, nil
+}
+
+// GetPublicContact retrieves public contact info for a person (HU55)
+// Only returns phone_number for motorcyclists to contact representatives
+func (i *Interactor) GetPublicContact(ctx context.Context, personID string) (*domain.Person, error) {
+	traceID := middleware.GetTraceIDFromContext(ctx)
+	log := i.logger.WithTraceID(traceID)
+
+	log.Info("GetPublicContact started", "person_id", personID)
+
+	person, err := i.service.GetPersonByID(ctx, personID)
+	if err != nil {
+		log.Error("error getting person for public contact", "person_id", personID, "error", err)
+		return nil, err
+	}
+
+	log.Success("GetPublicContact completed", "person_id", personID)
+	return person, nil
+}

--- a/core/interactor/services/domain/errors.go
+++ b/core/interactor/services/domain/errors.go
@@ -27,6 +27,8 @@ var (
 	ErrRoleRequired              = errors.New("ERR_ROLE_REQUIRED")
 	ErrUserCannotDelete          = errors.New("ERR_USER_CANNOT_DELETE")
 	ErrPasswordUpdateFailed      = errors.New("ERR_PASSWORD_UPDATE_FAILED")
+	ErrPasswordPolicyViolation   = errors.New("ERR_PASSWORD_POLICY_VIOLATION")
+	ErrInvalidCredentials        = errors.New("ERR_INVALID_CREDENTIALS")
 )
 
 // Infrastructure Errors (MOD_INFRA_*)
@@ -116,11 +118,12 @@ const (
 
 // Person Module (MOD_P_*)
 const (
-	MsgPersonNotFound     = "MOD_P_NOT_FOUND_ERR_00001"
-	MsgPersonInvalidTx    = "MOD_P_TRANS_ERR_00002"
-	MsgPersonRegistered   = "MOD_P_REG_EXI_00001"
-	MsgPersonUpdated      = "MOD_P_UPD_EXI_00002"
-	MsgPersonCannotDelete = "MOD_P_DEL_ERR_00003"
+	MsgPersonNotFound         = "MOD_P_NOT_FOUND_ERR_00001"
+	MsgPersonInvalidTx        = "MOD_P_TRANS_ERR_00002"
+	MsgPersonRegistered       = "MOD_P_REG_EXI_00001"
+	MsgPersonUpdated          = "MOD_P_UPD_EXI_00002"
+	MsgPersonCannotDelete     = "MOD_P_DEL_ERR_00003"
+	MsgPersonContactRetrieved = "MOD_P_CONTACT_EXI_00001" // HU55: Public contact retrieved
 )
 
 // Validation Module (MOD_V_*)
@@ -214,4 +217,9 @@ const (
 	MsgKCPwdResetError = "MOD_KC_PWD_RESET_ERROR_ERR_00001"
 	// Auth Profile
 	MsgAuthProfileRetrieved = "MOD_AUTH_PROFILE_EXI_00001"
+	// Change Password (HU57)
+	MsgChangePasswordSuccess        = "MOD_P_CHANGE_EXI_00001"
+	MsgChangePasswordInvalidCurrent = "MOD_P_CHANGE_ERR_00001"
+	MsgChangePasswordUpdateError    = "MOD_P_CHANGE_ERR_00002"
+	MsgChangePasswordPolicyError    = "MOD_P_CHANGE_ERR_00003"
 )

--- a/core/interactor/services/person_services.go
+++ b/core/interactor/services/person_services.go
@@ -369,6 +369,27 @@ func contains(s, substr string) bool {
 	return false
 }
 
+// isPasswordPolicyError checks if an error is related to Keycloak password policy violation
+// Keycloak returns 400 Bad Request with specific messages when password doesn't meet policy requirements
+func isPasswordPolicyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// Common Keycloak password policy error patterns
+	return contains(errStr, "invalidPasswordMinLength") ||
+		contains(errStr, "invalidPasswordMinUpperCase") ||
+		contains(errStr, "invalidPasswordMinLowerCase") ||
+		contains(errStr, "invalidPasswordMinDigits") ||
+		contains(errStr, "invalidPasswordMinSpecialChars") ||
+		contains(errStr, "invalidPasswordNotUsername") ||
+		contains(errStr, "invalidPasswordRegex") ||
+		contains(errStr, "passwordHistory") ||
+		contains(errStr, "Password policy not met") ||
+		contains(errStr, "password policy") ||
+		contains(errStr, "400 Bad Request") // Keycloak typically returns 400 for policy violations
+}
+
 // GetUserByEmail retrieves a user from Keycloak by email
 func (s service) GetUserByEmail(ctx context.Context, email string) (*gocloak.User, error) {
 	s.logger.Debug(logger.LogKeycloakSearchUserByEmail, "email", email)
@@ -513,5 +534,100 @@ func (s service) ResetPasswordWithToken(ctx context.Context, token string, newPa
 	}
 
 	s.logger.Success(logger.LogPasswordResetSuccess, "email", email, "user_id", *user.ID)
+	return nil
+}
+
+// ChangePassword verifies the current password by attempting a login
+// If successful, updates the password in Keycloak (HU57)
+func (s service) ChangePassword(ctx context.Context, keycloakUserID, currentPassword, newPassword string) error {
+	s.logger.Info(logger.LogChangePasswordStart, "keycloak_user_id", keycloakUserID)
+
+	// Get user to retrieve email for password verification
+	user, err := s.keycloak.GetUserByID(ctx, keycloakUserID)
+	if err != nil {
+		// Check if Keycloak is unavailable
+		if isConnectionError(err) || isTimeoutError(err) {
+			s.logger.Error(logger.LogKeycloakUnavailable,
+				"keycloak_user_id", keycloakUserID,
+				"error", err,
+				"error_type", "connection")
+			return domain.ErrKeycloakUnavailable
+		}
+		s.logger.Error(logger.LogChangePasswordUserNotFound, "keycloak_user_id", keycloakUserID, "error", err)
+		return domain.ErrUserNotFound
+	}
+
+	// Verify current password by attempting login
+	_, err = s.keycloak.LoginUser(ctx, *user.Email, currentPassword)
+	if err != nil {
+		// Check if Keycloak is unavailable during login attempt
+		if isConnectionError(err) || isTimeoutError(err) {
+			s.logger.Error(logger.LogKeycloakUnavailable,
+				"keycloak_user_id", keycloakUserID,
+				"error", err,
+				"error_type", "connection")
+			return domain.ErrKeycloakUnavailable
+		}
+		s.logger.Warn(logger.LogChangePasswordInvalidCurrent, "keycloak_user_id", keycloakUserID)
+		return domain.ErrInvalidCredentials
+	}
+
+	// Current password verified, set new password
+	if err := s.keycloak.SetPassword(ctx, keycloakUserID, newPassword, false); err != nil {
+		// Check if Keycloak is unavailable during password update
+		if isConnectionError(err) || isTimeoutError(err) {
+			s.logger.Error(logger.LogKeycloakUnavailable,
+				"keycloak_user_id", keycloakUserID,
+				"error", err,
+				"error_type", "connection")
+			return domain.ErrKeycloakUnavailable
+		}
+		// Check if error is due to password policy violation
+		if isPasswordPolicyError(err) {
+			s.logger.Warn("Password policy violation", "keycloak_user_id", keycloakUserID, "error", err)
+			return domain.ErrPasswordPolicyViolation
+		}
+		s.logger.Error(logger.LogChangePasswordUpdateError, "keycloak_user_id", keycloakUserID, "error", err)
+		return domain.ErrPasswordUpdateFailed
+	}
+
+	s.logger.Success(logger.LogChangePasswordSuccess, "keycloak_user_id", keycloakUserID)
+	return nil
+}
+
+// UpdatePersonProfile updates person data in DB and optionally syncs to Keycloak (HU52)
+// This method updates the person's profile information excluding email and password
+func (s service) UpdatePersonProfile(ctx context.Context, tx output.Tx, person domain.Person) error {
+	s.logger.Info(logger.LogUpdateProfileStart, "person_id", person.ID, "email", person.Email)
+
+	// Update person in database
+	if err := s.repository.UpdatePerson(ctx, tx, person); err != nil {
+		s.logger.Error(logger.LogUpdateProfileError, "person_id", person.ID, "error", err)
+		return err
+	}
+	s.logger.Success(logger.LogUpdateProfileDBSuccess, "person_id", person.ID)
+
+	// Optionally sync first_name and last_name to Keycloak for consistency
+	if person.KeycloakUserID != "" {
+		// Build gocloak.User structure for update
+		keycloakUser := &gocloak.User{
+			ID:        gocloak.StringP(person.KeycloakUserID),
+			FirstName: gocloak.StringP(person.FirstName),
+			LastName:  gocloak.StringP(person.LastName),
+		}
+		if err := s.keycloak.UpdateUser(ctx, keycloakUser); err != nil {
+			// Log warning but don't fail - DB update is the primary source of truth
+			s.logger.Warn(logger.LogUpdateProfileKeycloakSyncWarn,
+				"person_id", person.ID,
+				"keycloak_user_id", person.KeycloakUserID,
+				"error", err)
+		} else {
+			s.logger.Success(logger.LogUpdateProfileKeycloakSyncOK,
+				"person_id", person.ID,
+				"keycloak_user_id", person.KeycloakUserID)
+		}
+	}
+
+	s.logger.Success(logger.LogUpdateProfileSuccess, "person_id", person.ID)
 	return nil
 }

--- a/core/ports/input/service.go
+++ b/core/ports/input/service.go
@@ -39,6 +39,12 @@ type Service interface {
 	// ResetPasswordWithToken receives a JWT token, extracts the email, and updates the password in Keycloak
 	// Returns nil on success
 	ResetPasswordWithToken(ctx context.Context, token string, newPassword string) error
+	// ChangePassword verifies the current password and updates to the new password (HU57)
+	// Returns nil on success, ErrInvalidCredentials if current password is wrong
+	ChangePassword(ctx context.Context, keycloakUserID, currentPassword, newPassword string) error
+	// UpdatePersonProfile updates person data in DB and optionally syncs to Keycloak (HU52)
+	// Returns updated person on success
+	UpdatePersonProfile(ctx context.Context, tx output.Tx, person domain.Person) error
 
 	// Person - Compensaciones (rollback)
 	RollbackPerson(ctx context.Context, personID string) error

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"github.com/EstebanGitPro/motogo-backend/core/interactor"
 	domain "github.com/EstebanGitPro/motogo-backend/core/interactor/services/domain"
-	"github.com/EstebanGitPro/motogo-backend/core/ports/input"
 	"github.com/EstebanGitPro/motogo-backend/middleware"
 	messagingCache "github.com/EstebanGitPro/motogo-backend/platform/cache/messaging"
 	"github.com/EstebanGitPro/motogo-backend/platform/logger"
@@ -12,7 +11,6 @@ import (
 )
 
 type handler struct {
-	PersonService     input.Service
 	Interactor        *interactor.Interactor
 	MessageInteractor *interactor.MessageInteractor
 	MessagingCache    *messagingCache.MessageCache
@@ -20,9 +18,8 @@ type handler struct {
 	Response          *middleware.ResponseHandler
 }
 
-func New(service input.Service, personInteractor *interactor.Interactor, messageInteractor *interactor.MessageInteractor, messageCache *messagingCache.MessageCache, encoder *idencoder.HashidsEncoder, responseHandler *middleware.ResponseHandler) *handler {
+func New(personInteractor *interactor.Interactor, messageInteractor *interactor.MessageInteractor, messageCache *messagingCache.MessageCache, encoder *idencoder.HashidsEncoder, responseHandler *middleware.ResponseHandler) *handler {
 	return &handler{
-		PersonService:     service,
 		Interactor:        personInteractor,
 		MessageInteractor: messageInteractor,
 		MessagingCache:    messageCache,

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -22,7 +22,6 @@ func createTestEncoder() *idencoder.HashidsEncoder {
 
 func TestNew_CreatesHandler(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	mockCache := new(mocks.MockMessageCache)
 	encoder := createTestEncoder()
 	responseHandler := middleware.NewResponseHandler(nil)
@@ -31,7 +30,7 @@ func TestNew_CreatesHandler(t *testing.T) {
 	// For now, we're testing that handler creation works with nil interactors
 
 	// Act
-	handler := handlers.New(mockService, nil, nil, nil, encoder, responseHandler)
+	handler := handlers.New(nil, nil, nil, encoder, responseHandler)
 
 	// Assert
 	assert.NotNil(t, handler)
@@ -40,9 +39,8 @@ func TestNew_CreatesHandler(t *testing.T) {
 
 func TestEncodeID_Success(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	testUUID := "a1234567-89ab-cdef-0123-456789abcdef"
 
@@ -57,9 +55,8 @@ func TestEncodeID_Success(t *testing.T) {
 
 func TestEncodeID_InvalidUUID(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	// Act
 	encoded, err := handler.EncodeID("not-a-valid-uuid")
@@ -71,9 +68,8 @@ func TestEncodeID_InvalidUUID(t *testing.T) {
 
 func TestDecodeID_Success(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	testUUID := "a1234567-89ab-cdef-0123-456789abcdef"
 	encoded, _ := handler.EncodeID(testUUID)
@@ -88,9 +84,8 @@ func TestDecodeID_Success(t *testing.T) {
 
 func TestDecodeID_InvalidEncoded(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	// Act
 	decoded, err := handler.DecodeID("invalid-encoded-id")
@@ -102,9 +97,8 @@ func TestDecodeID_InvalidEncoded(t *testing.T) {
 
 func TestDecodeID_EmptyString(t *testing.T) {
 	// Arrange
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	// Act
 	decoded, err := handler.DecodeID("")
@@ -121,9 +115,8 @@ func TestHandleIDDecodingError_SetsError(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest("GET", "/test", nil)
 
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	// Act
 	handler.HandleIDDecodingError(c, "bad-id", assert.AnError)
@@ -139,9 +132,8 @@ func TestHandleIDEncodingError_SetsError(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest("GET", "/test", nil)
 
-	mockService := new(mocks.MockService)
 	encoder := createTestEncoder()
-	handler := handlers.New(mockService, nil, nil, nil, encoder, nil)
+	handler := handlers.New(nil, nil, nil, encoder, nil)
 
 	// Act
 	handler.HandleIDEncodingError(c, "some-uuid", assert.AnError)

--- a/handlers/hateoas.go
+++ b/handlers/hateoas.go
@@ -182,9 +182,14 @@ func BuildLoginLinks(baseURL string) []Link {
 func BuildAuthMeLinks(baseURL string) []Link {
 	return []Link{
 		{
-			Href:   fmt.Sprintf("%s/motogo/api/v1/auth/me", baseURL),
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me", baseURL),
 			Rel:    "self",
 			Method: "GET",
+		},
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me/password", baseURL),
+			Rel:    "change-password",
+			Method: "PUT",
 		},
 		{
 			Href:   fmt.Sprintf("%s/motogo/api/v1/auth/login", baseURL),
@@ -214,6 +219,62 @@ func BuildAccountCreatedLinks(baseURL string, accountID string) []Link {
 			Href:   fmt.Sprintf("%s/motogo/api/v1/auth/verify-email", baseURL),
 			Rel:    "verify-email",
 			Method: "POST",
+		},
+	}
+}
+
+// BuildChangePasswordLinks constructs HATEOAS links for password change response (HU57)
+// Returns links to profile and login after successful password change
+func BuildChangePasswordLinks(baseURL string) []Link {
+	return []Link{
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me", baseURL),
+			Rel:    "profile",
+			Method: "GET",
+		},
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/auth/login", baseURL),
+			Rel:    "login",
+			Method: "POST",
+		},
+	}
+}
+
+// BuildUpdateProfileLinks constructs HATEOAS links for profile update response (HU52)
+// Richardson Maturity Model Level 3: Provides discoverable next actions
+func BuildUpdateProfileLinks(baseURL string) []Link {
+	return []Link{
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me", baseURL),
+			Rel:    "self",
+			Method: "GET",
+		},
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me", baseURL),
+			Rel:    "update",
+			Method: "PUT",
+		},
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/me/password", baseURL),
+			Rel:    "change-password",
+			Method: "PUT",
+		},
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/auth/login", baseURL),
+			Rel:    "login",
+			Method: "POST",
+		},
+	}
+}
+
+// BuildPublicContactLinks constructs HATEOAS links for public contact response (HU55)
+// Para motociclistas viendo info de contacto del representante
+func BuildPublicContactLinks(baseURL string, personID string) []Link {
+	return []Link{
+		{
+			Href:   fmt.Sprintf("%s/motogo/api/v1/persons/%s/contact", baseURL, personID),
+			Rel:    "self",
+			Method: "GET",
 		},
 	}
 }

--- a/handlers/hateoas_test.go
+++ b/handlers/hateoas_test.go
@@ -192,7 +192,7 @@ func TestBuildLoginLinks(t *testing.T) {
 
 	profileLink := findLinkByRel(links, "profile")
 	assert.NotNil(t, profileLink)
-	assert.Contains(t, profileLink.Href, "/auth/me")
+	assert.Contains(t, profileLink.Href, "/auth/me") // Login still points to /auth/me as it's a public reference
 
 	resetLink := findLinkByRel(links, "password-reset")
 	assert.NotNil(t, resetLink)
@@ -203,12 +203,16 @@ func TestBuildAuthMeLinks(t *testing.T) {
 	// Act
 	links := handlers.BuildAuthMeLinks("http://localhost:8080")
 
-	// Assert
-	assert.Len(t, links, 2)
+	// Assert - now returns 3 links: self, change-password, login
+	assert.Len(t, links, 3)
 
 	selfLink := findLinkByRel(links, "self")
 	assert.NotNil(t, selfLink)
-	assert.Contains(t, selfLink.Href, "/auth/me")
+	assert.Contains(t, selfLink.Href, "/persons/me")
+
+	changePasswordLink := findLinkByRel(links, "change-password")
+	assert.NotNil(t, changePasswordLink)
+	assert.Contains(t, changePasswordLink.Href, "/persons/me/password")
 
 	loginLink := findLinkByRel(links, "login")
 	assert.NotNil(t, loginLink)

--- a/handlers/person.go
+++ b/handlers/person.go
@@ -96,3 +96,46 @@ type ResetPasswordWithTokenRequest struct {
 	Token       string `json:"token" binding:"required"`
 	NewPassword string `json:"new_password" binding:"required,min=8"`
 }
+
+// ChangePasswordRequest - DTO para cambiar contraseña estando autenticado (HU57)
+// El usuario debe proporcionar su contraseña actual para verificar identidad
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password" binding:"required,min=8"`
+	NewPassword     string `json:"new_password" binding:"required,min=8"`
+}
+
+// ChangePasswordResponse - Respuesta del cambio de contraseña (HU57)
+type ChangePasswordResponse struct {
+	Message string `json:"message"`
+	Links   []Link `json:"_links"`
+}
+
+// UpdateProfileRequest - DTO for updating profile (HU52)
+// All fields are optional (PATCH-like behavior)
+type UpdateProfileRequest struct {
+	IdentityNumber string `json:"identity_number,omitempty"`
+	FirstName      string `json:"first_name,omitempty"`
+	LastName       string `json:"last_name,omitempty"`
+	SecondLastName string `json:"second_last_name,omitempty"`
+	PhoneNumber    string `json:"phone_number,omitempty"`
+}
+
+// UpdateProfileResponse - Response for profile update (HU52)
+type UpdateProfileResponse struct {
+	ID             string `json:"id"`
+	IdentityNumber string `json:"identity_number"`
+	Email          string `json:"email"`
+	FirstName      string `json:"first_name"`
+	LastName       string `json:"last_name"`
+	SecondLastName string `json:"second_last_name,omitempty"`
+	PhoneNumber    string `json:"phone_number,omitempty"`
+	Role           string `json:"role"`
+	Links          []Link `json:"_links"`
+}
+
+// PublicContactResponse - Solo info de contacto para motociclistas (HU55)
+// Endpoint público para que puedan contactar al representante de sede
+type PublicContactResponse struct {
+	PhoneNumber string `json:"phone_number"`
+	Links       []Link `json:"_links"`
+}

--- a/handlers/person_controller.go
+++ b/handlers/person_controller.go
@@ -288,6 +288,8 @@ func (h handler) ResetPasswordWithToken() gin.HandlerFunc {
 				h.Response.Error(c, "MOD_P_RESET_ERR_00002")
 			case domain.ErrPasswordUpdateFailed:
 				log.Error(logger.LogPasswordResetUpdateError, "error", err, "client_ip", c.ClientIP())
+                case domain.ErrPasswordPolicyViolation:
+                        h.Response.Error(c, domain.MsgChangePasswordPolicyError)
 				h.Response.Error(c, "MOD_P_RESET_ERR_00003")
 			default:
 				log.Error(logger.LogPasswordResetUpdateError, "error", err, "client_ip", c.ClientIP())
@@ -353,5 +355,225 @@ func (h handler) GetAuthenticatedUser() gin.HandlerFunc {
 
 		log.Success("user profile retrieved successfully", "user_id", encodedID, "email", person.Email)
 		h.Response.SuccessWithData(c, domain.MsgAuthProfileRetrieved, response)
+	}
+}
+
+// @Summary Cambiar contraseña del usuario autenticado
+// @Description Permite al usuario autenticado cambiar su contraseña proporcionando la contraseña actual
+// @Tags Autenticación
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param request body ChangePasswordRequest true "Contraseña actual y nueva"
+// @Success 200 {object} middleware.APIResponse{data=ChangePasswordResponse} "Contraseña actualizada exitosamente"
+// @Failure 400 {object} middleware.APIResponse "Formato inválido o contraseña no cumple requisitos"
+// @Failure 401 {object} middleware.APIResponse "Token inválido o contraseña actual incorrecta"
+// @Failure 500 {object} middleware.APIResponse "Error interno del servidor"
+// @Router /persons/me/password [put]
+func (h handler) ChangePassword() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := middleware.GetRequestID(c)
+		log := Logger.WithTraceID(traceID)
+
+		// Get authenticated user from context (injected by JWT middleware)
+		person, ok := middleware.GetAuthenticatedUser(c)
+		if !ok {
+			log.Error("authenticated user not found in context")
+			c.Error(domain.ErrUserNotFound)
+			return
+		}
+
+		var req ChangePasswordRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Error(logger.LogRegJSONParseError, "error", err)
+			h.Response.Error(c, domain.MsgValBadFormat)
+			return
+		}
+
+		log.Info(logger.LogChangePasswordStart, "user_id", person.KeycloakUserID, "client_ip", c.ClientIP())
+
+		// Call interactor to change password
+		err := h.Interactor.ChangePassword(c, person.KeycloakUserID, req.CurrentPassword, req.NewPassword)
+		if err != nil {
+			log.Error(logger.LogChangePasswordUpdateError, "user_id", person.KeycloakUserID, "error", err, "client_ip", c.ClientIP())
+
+			switch err {
+			case domain.ErrInvalidCredentials:
+				h.Response.Error(c, domain.MsgChangePasswordInvalidCurrent)
+			case domain.ErrUserNotFound:
+				h.Response.Error(c, domain.MsgKCUserNotFound)
+			case domain.ErrPasswordUpdateFailed:
+				h.Response.Error(c, domain.MsgChangePasswordUpdateError)
+                case domain.ErrPasswordPolicyViolation:
+                        h.Response.Error(c, domain.MsgChangePasswordPolicyError)
+			case domain.ErrKeycloakUnavailable:
+				h.Response.Error(c, domain.MsgKeycloakUnavailable)
+			default:
+				h.Response.Error(c, domain.MsgChangePasswordUpdateError)
+			}
+			return
+		}
+
+		// Build HATEOAS links for change password response
+		baseURL := GetBaseURL(c)
+		hateoasLinks := BuildChangePasswordLinks(baseURL)
+
+		response := ChangePasswordResponse{
+			Message: "Password changed successfully",
+			Links:   hateoasLinks,
+		}
+
+		log.Success(logger.LogChangePasswordSuccess, "user_id", person.KeycloakUserID, "client_ip", c.ClientIP())
+		h.Response.SuccessWithData(c, domain.MsgChangePasswordSuccess, response)
+	}
+}
+
+// @Summary Actualizar perfil del usuario autenticado
+// @Description Permite al usuario autenticado actualizar su información de perfil (excepto email y contraseña)
+// @Tags Autenticación
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param request body UpdateProfileRequest true "Datos del perfil a actualizar"
+// @Success 200 {object} middleware.APIResponse{data=UpdateProfileResponse} "Perfil actualizado exitosamente"
+// @Failure 400 {object} middleware.APIResponse "Formato inválido"
+// @Failure 401 {object} middleware.APIResponse "Token inválido o ausente"
+// @Failure 409 {object} middleware.APIResponse "Datos duplicados (teléfono o número de identidad)"
+// @Failure 500 {object} middleware.APIResponse "Error interno del servidor"
+// @Router /persons/me [put]
+func (h handler) UpdateProfile() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := middleware.GetRequestID(c)
+		log := Logger.WithTraceID(traceID)
+
+		// Get authenticated user from context (injected by JWT middleware)
+		person, ok := middleware.GetAuthenticatedUser(c)
+		if !ok {
+			log.Error("authenticated user not found in context")
+			c.Error(domain.ErrUserNotFound)
+			return
+		}
+
+		var req UpdateProfileRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Error(logger.LogRegJSONParseError, "error", err)
+			h.Response.Error(c, domain.MsgValBadFormat)
+			return
+		}
+
+		log.Info(logger.LogUpdateProfileStart, "user_id", person.ID, "client_ip", c.ClientIP())
+
+		// Merge request with existing person data (only update provided fields)
+		updatedPerson := *person
+		if req.IdentityNumber != "" {
+			updatedPerson.IdentityNumber = req.IdentityNumber
+		}
+		if req.FirstName != "" {
+			updatedPerson.FirstName = req.FirstName
+		}
+		if req.LastName != "" {
+			updatedPerson.LastName = req.LastName
+		}
+		if req.SecondLastName != "" {
+			updatedPerson.SecondLastName = req.SecondLastName
+		}
+		if req.PhoneNumber != "" {
+			updatedPerson.PhoneNumber = req.PhoneNumber
+		}
+
+		// Call interactor to update profile
+		result, err := h.Interactor.UpdateProfile(c, updatedPerson)
+		if err != nil {
+			log.Error(logger.LogUpdateProfileError, "user_id", person.ID, "error", err, "client_ip", c.ClientIP())
+
+			switch err {
+			case domain.ErrDuplicateUser:
+				h.Response.Error(c, domain.MsgUserDuplicate)
+			default:
+				h.Response.Error(c, domain.MsgPersonUpdated)
+			}
+			return
+		}
+
+		// Encode ID for response
+		encodedID, err := h.EncodeID(result.ID)
+		if err != nil {
+			log.Error("error encoding user ID", "error", err, "user_id", result.ID)
+			c.Error(err)
+			return
+		}
+
+		// Build HATEOAS links for profile update response
+		baseURL := GetBaseURL(c)
+		hateoasLinks := BuildUpdateProfileLinks(baseURL)
+
+		response := UpdateProfileResponse{
+			ID:             encodedID,
+			IdentityNumber: result.IdentityNumber,
+			Email:          result.Email,
+			FirstName:      result.FirstName,
+			LastName:       result.LastName,
+			SecondLastName: result.SecondLastName,
+			PhoneNumber:    result.PhoneNumber,
+			Role:           result.Role,
+			Links:          hateoasLinks,
+		}
+
+		log.Success(logger.LogUpdateProfileSuccess, "user_id", encodedID, "client_ip", c.ClientIP())
+		h.Response.SuccessWithData(c, domain.MsgPersonUpdated, response)
+	}
+}
+
+// @Summary Obtener información de contacto pública de un representante
+// @Description Permite a motociclistas obtener el número de contacto de un representante de sede
+// @Tags Personas
+// @Produce json
+// @Param id path string true "ID ofuscado del representante"
+// @Success 200 {object} middleware.APIResponse{data=PublicContactResponse} "Info de contacto obtenida"
+// @Failure 400 {object} middleware.APIResponse "ID inválido"
+// @Failure 404 {object} middleware.APIResponse "Representante no encontrado"
+// @Router /persons/{id}/contact [get]
+func (h handler) GetPublicContact() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := middleware.GetRequestID(c)
+		log := Logger.WithTraceID(traceID)
+
+		// Get and decode person ID from URL param
+		encodedID := c.Param("id")
+		if encodedID == "" {
+			log.Error("missing person ID in URL")
+			h.Response.Error(c, domain.MsgValBadFormat)
+			return
+		}
+
+		personID, err := h.DecodeID(encodedID)
+		if err != nil {
+			log.Error("error decoding person ID", "encoded_id", encodedID, "error", err)
+			h.Response.Error(c, domain.MsgValBadFormat)
+			return
+		}
+
+		log.Info("getting public contact info", "person_id", personID, "client_ip", c.ClientIP())
+
+		// Get person from interactor (Clean Architecture - HU55)
+		person, err := h.Interactor.GetPublicContact(c, personID)
+		if err != nil {
+			log.Error("error getting person", "person_id", personID, "error", err)
+			c.Error(domain.ErrPersonNotFound)
+			return
+		}
+
+		// Build HATEOAS links
+		baseURL := GetBaseURL(c)
+		hateoasLinks := BuildPublicContactLinks(baseURL, encodedID)
+
+		// Return only phone number (non-sensitive contact info)
+		response := PublicContactResponse{
+			PhoneNumber: person.PhoneNumber,
+			Links:       hateoasLinks,
+		}
+
+		log.Success("public contact info retrieved", "person_id", personID, "client_ip", c.ClientIP())
+		h.Response.SuccessWithData(c, domain.MsgPersonContactRetrieved, response)
 	}
 }

--- a/middleware/error_handler.go
+++ b/middleware/error_handler.go
@@ -80,6 +80,11 @@ var errorToMessageCode = map[error]string{
 	// Incomplete registration (cleanup in progress)
 	domain.ErrIncompleteRegistration: domain.MsgIncompleteRegistration,
 
+	// Authentication errors (401 Unauthorized)
+	domain.ErrInvalidToken:       domain.MsgUnauthorized,
+	domain.ErrInvalidCredentials: domain.MsgUnauthorized,
+	domain.ErrTokenExpired:       domain.MsgUserTokenExpired,
+
 	// General errors
 	domain.ErrInternalServer: domain.MsgServerError,
 }
@@ -90,11 +95,10 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-var log   logger.Logger = logger.NewSlogLogger()
+var log logger.Logger = logger.NewSlogLogger()
 
 type ErrorHandler struct {
 	cache *messagingCache.MessageCache
-	
 }
 
 func NewErrorHandler(cache *messagingCache.MessageCache) *ErrorHandler {

--- a/middleware/json_validator.go
+++ b/middleware/json_validator.go
@@ -42,6 +42,18 @@ func (b *Builder) WithValidatePasswordReset() gin.HandlerFunc {
 	return b.jsonValidator(b.Validators.PasswordResetValidator)
 }
 
+func (b *Builder) WithValidateUpdateProfile() gin.HandlerFunc {
+	return b.jsonValidator(b.Validators.UpdateProfileValidator)
+}
+
+func (b *Builder) WithValidateResetPasswordWithToken() gin.HandlerFunc {
+	return b.jsonValidator(b.Validators.ResetPasswordWithTokenValidator)
+}
+
+func (b *Builder) WithValidateChangePassword() gin.HandlerFunc {
+	return b.jsonValidator(b.Validators.ChangePasswordValidator)
+}
+
 func (b *Builder) jsonValidator(schema *jsonschema.Schema) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Get request ID for trace correlation

--- a/mocks/mock_service.go
+++ b/mocks/mock_service.go
@@ -142,3 +142,15 @@ func (m *MockService) GetPersonByKeycloakID(ctx context.Context, keycloakUserID 
 	}
 	return args.Get(0).(*domain.Person), args.Error(1)
 }
+
+// ChangePassword mocks the service method (HU57)
+func (m *MockService) ChangePassword(ctx context.Context, keycloakUserID, currentPassword, newPassword string) error {
+	args := m.Called(ctx, keycloakUserID, currentPassword, newPassword)
+	return args.Error(0)
+}
+
+// UpdatePersonProfile mocks the service method (HU52)
+func (m *MockService) UpdatePersonProfile(ctx context.Context, tx output.Tx, person domain.Person) error {
+	args := m.Called(ctx, tx, person)
+	return args.Error(0)
+}

--- a/platform/cache/messaging/cache.go
+++ b/platform/cache/messaging/cache.go
@@ -228,6 +228,16 @@ var messageCodeToHTTPStatus = map[string]int{
 	// Person Module (MOD_P_*)
 	// ========================================
 	"MOD_P_NOT_FOUND_ERR_00001": http.StatusNotFound, // 404 - Persona no encontrada
+	// Password Reset (HU56)
+	"MOD_P_RESET_EXI_00001": http.StatusOK,                  // 200 - Password reset exitoso
+	"MOD_P_RESET_ERR_00001": http.StatusBadRequest,          // 400 - Token inválido
+	"MOD_P_RESET_ERR_00002": http.StatusNotFound,            // 404 - Usuario no encontrado
+	"MOD_P_RESET_ERR_00003": http.StatusInternalServerError, // 500 - Error actualizando password
+	// Change Password (HU57)
+	"MOD_P_CHANGE_EXI_00001": http.StatusOK,                  // 200 - Password cambiado exitosamente
+	"MOD_P_CHANGE_ERR_00001": http.StatusUnauthorized,        // 401 - Contraseña actual incorrecta
+	"MOD_P_CHANGE_ERR_00002": http.StatusUnprocessableEntity, // 422 - Error procesando cambio de contraseña
+	"MOD_P_CHANGE_ERR_00003": http.StatusBadRequest,          // 400 - Contraseña no cumple requisitos
 
 	// ========================================
 	// Validation Module (MOD_V_*)

--- a/platform/databases/repositories/person/update.go
+++ b/platform/databases/repositories/person/update.go
@@ -17,7 +17,6 @@ func (r *repository) UpdatePerson(ctx context.Context, tx output.Tx, person doma
 		return domain.ErrInvalidTransaction
 	}
 
-	// Solo ejecutar el query - NO manejar commit/rollback
 	_, err := dbTx.ExecContext(ctx, queryUpdate,
 		personToUpdate.IdentityNumber,
 		personToUpdate.FirstName,
@@ -27,7 +26,7 @@ func (r *repository) UpdatePerson(ctx context.Context, tx output.Tx, person doma
 		personToUpdate.PhoneNumber,
 		personToUpdate.Role,
 		personToUpdate.KeycloakUserID,
-		personToUpdate.ID, // WHERE clause
+		personToUpdate.ID,
 	)
 
 	if err != nil {

--- a/platform/logger/log_messages.go
+++ b/platform/logger/log_messages.go
@@ -147,6 +147,20 @@ const (
 	LogPasswordResetUserFound      = "Usuario encontrado para reset de contraseña"
 	LogPasswordResetUpdateError    = "Error actualizando contraseña en Keycloak"
 	LogPasswordResetSuccess        = "Contraseña actualizada exitosamente"
+	// Change Password Flow (HU57)
+	LogChangePasswordStart          = "Iniciando proceso de cambio de contraseña"
+	LogChangePasswordUserNotFound   = "Usuario no encontrado para cambio de contraseña"
+	LogChangePasswordInvalidCurrent = "Contraseña actual incorrecta"
+	LogChangePasswordUpdateError    = "Error actualizando contraseña"
+	LogChangePasswordSuccess        = "Contraseña cambiada exitosamente"
+	// Update Profile Flow (HU52)
+	LogUpdateProfileStart            = "Iniciando proceso de actualización de perfil"
+	LogUpdateProfileValidation       = "Validando datos del perfil"
+	LogUpdateProfileDBSuccess        = "Perfil actualizado en base de datos"
+	LogUpdateProfileKeycloakSyncWarn = "Advertencia sincronizando perfil con Keycloak"
+	LogUpdateProfileKeycloakSyncOK   = "Perfil sincronizado con Keycloak"
+	LogUpdateProfileSuccess          = "Perfil actualizado exitosamente"
+	LogUpdateProfileError            = "Error actualizando perfil"
 )
 
 // ============================================

--- a/platform/schema/json_schemas/change_password_schema.json
+++ b/platform/schema/json_schemas/change_password_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Change Password Request",
+  "description": "Schema for changing password while authenticated (HU57)",
+  "properties": {
+    "current_password": {
+      "type": "string",
+      "description": "Current password for verification",
+      "minLength": 8,
+      "maxLength": 50
+    },
+    "new_password": {
+      "type": "string",
+      "description": "New password - minimum 8 characters, at least 1 uppercase (A-Z), 1 lowercase (a-z), and 1 number (0-9)",
+      "minLength": 8,
+      "maxLength": 50,
+      "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$"
+    }
+  },
+  "required": ["current_password", "new_password"],
+  "additionalProperties": false
+}

--- a/platform/schema/json_schemas/register_person_schema.json
+++ b/platform/schema/json_schemas/register_person_schema.json
@@ -47,9 +47,10 @@
     },
     "password": {
       "type": "string",
-      "description": "Access password",
+      "description": "Access password - minimum 8 characters, at least 1 uppercase (A-Z), 1 lowercase (a-z), and 1 number (0-9)",
       "minLength": 8,
-      "maxLength": 50
+      "maxLength": 50,
+      "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$"
     },
     "role": {
       "type": "string",

--- a/platform/schema/json_schemas/reset_password_with_token_schema.json
+++ b/platform/schema/json_schemas/reset_password_with_token_schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Reset Password With Token",
+  "description": "Schema for resetting password with token from email link",
+  "properties": {
+    "token": {
+      "type": "string",
+      "description": "JWT token from the password reset email link",
+      "minLength": 1
+    },
+    "new_password": {
+      "type": "string",
+      "description": "New password - minimum 8 characters, at least 1 uppercase (A-Z), 1 lowercase (a-z), and 1 number (0-9)",
+      "minLength": 8,
+      "maxLength": 50,
+      "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$"
+    }
+  },
+  "required": ["token", "new_password"],
+  "additionalProperties": false
+}

--- a/platform/schema/json_schemas/update_profile_schema.json
+++ b/platform/schema/json_schemas/update_profile_schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "identity_number": {
+      "type": "string",
+      "description": "Identity document number (ID card, passport, DNI, etc.)",
+      "maxLength": 10,
+      "minLength": 1
+    },
+    "first_name": {
+      "type": "string",
+      "description": "First name of the person",
+      "maxLength": 120,
+      "minLength": 1
+    },
+    "last_name": {
+      "type": "string",
+      "description": "Last name of the person",
+      "maxLength": 120,
+      "minLength": 1
+    },
+    "second_last_name": {
+      "type": "string",
+      "description": "Second last name of the person (optional)",
+      "maxLength": 120
+    },
+    "phone_number": {
+      "type": "string",
+      "description": "Cell phone number (10 digits)",
+      "pattern": "^[0-9]{10}$"
+    }
+  },
+  "minProperties": 1,
+  "additionalProperties": false
+}

--- a/platform/schema/schema.go
+++ b/platform/schema/schema.go
@@ -10,11 +10,14 @@ import (
 )
 
 type Validators struct {
-	FileReader                  FileReaderInterface
-	RegisterValidator           *jsonschema.Schema
-	MessageValidator            *jsonschema.Schema
-	ResendVerificationValidator *jsonschema.Schema
-	PasswordResetValidator      *jsonschema.Schema
+	FileReader                      FileReaderInterface
+	RegisterValidator               *jsonschema.Schema
+	MessageValidator                *jsonschema.Schema
+	ResendVerificationValidator     *jsonschema.Schema
+	PasswordResetValidator          *jsonschema.Schema
+	UpdateProfileValidator          *jsonschema.Schema
+	ResetPasswordWithTokenValidator *jsonschema.Schema
+	ChangePasswordValidator         *jsonschema.Schema
 }
 
 type FileReaderInterface interface {
@@ -66,10 +69,28 @@ func NewValidator(fileReader FileReaderInterface) (*Validators, error) {
 		return nil, err
 	}
 
+	updateProfile, err := validator.createSchema("update_profile_schema.json")
+	if err != nil {
+		return nil, err
+	}
+
+	resetPasswordWithToken, err := validator.createSchema("reset_password_with_token_schema.json")
+	if err != nil {
+		return nil, err
+	}
+
+	changePassword, err := validator.createSchema("change_password_schema.json")
+	if err != nil {
+		return nil, err
+	}
+
 	validator.RegisterValidator = register
 	validator.MessageValidator = message
 	validator.ResendVerificationValidator = resendVerification
 	validator.PasswordResetValidator = passwordReset
+	validator.UpdateProfileValidator = updateProfile
+	validator.ResetPasswordWithTokenValidator = resetPasswordWithToken
+	validator.ChangePasswordValidator = changePassword
 
 	return validator, nil
 

--- a/public/reset-password.html
+++ b/public/reset-password.html
@@ -124,9 +124,11 @@
 
       .password-requirements li::before {
         content: "•";
-        color: #667eea;
+        color: #94a3b8;
         font-weight: bold;
         margin-right: 0.5rem;
+        width: 16px;
+        text-align: center;
       }
 
       .password-requirements li.valid {
@@ -135,6 +137,16 @@
 
       .password-requirements li.valid::before {
         content: "✓";
+        color: #10b981;
+      }
+
+      .password-requirements li.invalid {
+        color: #ef4444;
+      }
+
+      .password-requirements li.invalid::before {
+        content: "✗";
+        color: #ef4444;
       }
 
       .error-message {
@@ -261,6 +273,9 @@
           </p>
           <ul id="requirements">
             <li id="req-length">Mínimo 8 caracteres</li>
+            <li id="req-uppercase">Al menos 1 letra mayúscula (A-Z)</li>
+            <li id="req-lowercase">Al menos 1 letra minúscula (a-z)</li>
+            <li id="req-digit">Al menos 1 número (0-9)</li>
             <li id="req-match">Las contraseñas coinciden</li>
           </ul>
         </div>
@@ -302,20 +317,47 @@
         const newPassword = newPasswordInput.value;
         const confirmPassword = confirmPasswordInput.value;
 
-        // Check length
-        const lengthReq = document.getElementById("req-length");
-        if (newPassword.length >= 8) {
-          lengthReq.classList.add("valid");
-        } else {
-          lengthReq.classList.remove("valid");
-        }
+        // Check length (min 8)
+        updateRequirement("req-length", newPassword.length >= 8);
+
+        // Check uppercase (at least 1)
+        updateRequirement("req-uppercase", /[A-Z]/.test(newPassword));
+
+        // Check lowercase (at least 1)
+        updateRequirement("req-lowercase", /[a-z]/.test(newPassword));
+
+        // Check digit (at least 1)
+        updateRequirement("req-digit", /[0-9]/.test(newPassword));
 
         // Check match
-        const matchReq = document.getElementById("req-match");
-        if (newPassword && confirmPassword && newPassword === confirmPassword) {
-          matchReq.classList.add("valid");
+        const matches =
+          newPassword && confirmPassword && newPassword === confirmPassword;
+        updateRequirement("req-match", matches);
+
+        // Enable/disable submit button
+        const allValid =
+          newPassword.length >= 8 &&
+          /[A-Z]/.test(newPassword) &&
+          /[a-z]/.test(newPassword) &&
+          /[0-9]/.test(newPassword) &&
+          matches;
+
+        submitBtn.disabled = !allValid;
+      }
+
+      function updateRequirement(id, isValid) {
+        const element = document.getElementById(id);
+        if (isValid) {
+          element.classList.add("valid");
+          element.classList.remove("invalid");
         } else {
-          matchReq.classList.remove("valid");
+          element.classList.remove("valid");
+          // Only show invalid if user has started typing
+          if (newPasswordInput.value.length > 0) {
+            element.classList.add("invalid");
+          } else {
+            element.classList.remove("invalid");
+          }
         }
       }
 
@@ -325,9 +367,24 @@
         const newPassword = newPasswordInput.value;
         const confirmPassword = confirmPasswordInput.value;
 
-        // Validations
+        // Final validations
         if (newPassword.length < 8) {
           showError("La contraseña debe tener al menos 8 caracteres");
+          return;
+        }
+
+        if (!/[A-Z]/.test(newPassword)) {
+          showError("La contraseña debe contener al menos 1 letra mayúscula");
+          return;
+        }
+
+        if (!/[a-z]/.test(newPassword)) {
+          showError("La contraseña debe contener al menos 1 letra minúscula");
+          return;
+        }
+
+        if (!/[0-9]/.test(newPassword)) {
+          showError("La contraseña debe contener al menos 1 número");
           return;
         }
 
@@ -366,10 +423,34 @@
             // Deshabilitar el formulario después del éxito
             form.style.display = "none";
           } else {
-            showError(
-              data.message ||
-                "Error al actualizar la contraseña. Por favor, intenta nuevamente."
-            );
+            // Parse error message from Keycloak/backend
+            let errorMsg =
+              "Error al actualizar la contraseña. Por favor, intenta nuevamente.";
+
+            if (data.message) {
+              // Check for specific Keycloak password policy errors
+              if (typeof data.message === "string") {
+                if (
+                  data.message.includes("password policies") ||
+                  data.message.includes("Invalid password")
+                ) {
+                  errorMsg =
+                    "La contraseña no cumple con las políticas de seguridad. Verifica que cumpla todos los requisitos mostrados arriba.";
+                } else if (
+                  data.message.includes("recently used") ||
+                  data.message.includes("Not Recently Used")
+                ) {
+                  errorMsg =
+                    "No puedes usar una contraseña que hayas usado recientemente. Por favor, elige una contraseña diferente.";
+                } else {
+                  errorMsg = data.message;
+                }
+              } else if (data.message.contenido) {
+                errorMsg = data.message.contenido;
+              }
+            }
+
+            showError(errorMsg);
             submitBtn.disabled = false;
             btnText.style.display = "block";
             spinner.style.display = "none";
@@ -403,6 +484,9 @@
         document.getElementById("errorMessage").style.display = "none";
         document.getElementById("successMessage").style.display = "none";
       }
+
+      // Initialize validation state
+      validatePassword();
     </script>
   </body>
 </html>

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func routing(app *gin.Engine, dependencies *dependency.Dependencies) {
 	errorHandler := middleware.NewErrorHandler(dependencies.MessagingCache)
 	app.Use(errorHandler.Handle())
 
-	handler := handlers.New(dependencies.PersonService, dependencies.Interactor, dependencies.MessageInteractor, dependencies.MessagingCache, dependencies.IDEncoder, dependencies.ResponseHandler)
+	handler := handlers.New(dependencies.Interactor, dependencies.MessageInteractor, dependencies.MessagingCache, dependencies.IDEncoder, dependencies.ResponseHandler)
 
 	validators, err := schema.NewValidator(&schema.DefaultFileReader{})
 	if err != nil {
@@ -124,6 +124,9 @@ func routing(app *gin.Engine, dependencies *dependency.Dependencies) {
 		// POST /messages/cache/reload - Recargar caché de mensajes desde BD
 		// Endpoint administrativo para forzar recarga después de cambios manuales
 		public.POST("/messages/cache/reload", handler.ReloadMessageCache())
+
+		// GET /persons/:id/contact - Obtener info de contacto pública (HU55)
+		public.GET("/persons/:id/contact", handler.GetPublicContact())
 	}
 
 	// ========================================
@@ -132,8 +135,14 @@ func routing(app *gin.Engine, dependencies *dependency.Dependencies) {
 	protected := app.Group("motogo/api/v1")
 	protected.Use(middleware.RequireAuth(dependencies.PersonService, dependencies.MessagingCache))
 	{
-		// GET /persons/me - Obtener perfil del usuario autenticado 
+		// GET /persons/me - Obtener perfil del usuario autenticado
 		protected.GET("/persons/me", handler.GetAuthenticatedUser())
+
+		// PUT /persons/me - Actualizar perfil del usuario autenticado (HU52)
+		protected.PUT("/persons/me", handler.UpdateProfile())
+
+		// PUT /persons/me/password - Cambiar contraseña del usuario autenticado (HU57)
+		protected.PUT("/persons/me/password", handler.ChangePassword())
 	}
 
 	dependencies.Logger.Success(logger.LogRouteConfigured)


### PR DESCRIPTION
- Added ChangePassword method to Service interface for changing user passwords.
- Introduced UpdatePersonProfile method to Service interface for updating user profiles.
- Created ChangePasswordRequest and ChangePasswordResponse DTOs for handling password change requests and responses.
- Developed UpdateProfileRequest and UpdateProfileResponse DTOs for profile updates.
- Implemented ChangePassword and UpdateProfile handlers in person_controller.go.
- Added HATEOAS links for Change Password and Update Profile responses.
- Updated error handling for password change and profile update processes.
- Created JSON schemas for Change Password, Update Profile, and Reset Password with Token.
- Enhanced frontend validation for password requirements in reset-password.html.
- Updated routing to include new endpoints for changing password and updating profile.