### PR TITLE
Release v0.14.4: Fix Keycloak email verification URL for production

### DIFF
--- a/tools/keycloak-themes/motogo/email/html/executeActions.ftl
+++ b/tools/keycloak-themes/motogo/email/html/executeActions.ftl
@@ -55,7 +55,13 @@
                 <#assign customLink = link>
                 <#if requiredActions?? && requiredActions?seq_contains("UPDATE_PASSWORD")>
                     <#-- Extract token from Keycloak link: http://keycloak/realms/realm/login-actions/action-token?key=TOKEN -->
-                    <#assign customLink = "http://localhost:8085/reset-password.html?token=" + link?replace(".*key=", "", "r")>
+                    <#-- Determine API base: local vs production -->
+                    <#if link?contains("localhost")>
+                        <#assign apiBase = "http://localhost:8085">
+                    <#else>
+                        <#assign apiBase = "https://api.rbsuport.com">
+                    </#if>
+                    <#assign customLink = apiBase + "/reset-password.html?token=" + link?replace(".*key=", "", "r")>
                 </#if>
                 
                 <div style="text-align: center; margin: 1.5rem 0;">

--- a/tools/keycloak-themes/motogo/login/info.ftl
+++ b/tools/keycloak-themes/motogo/login/info.ftl
@@ -180,8 +180,15 @@
     
     <script>
         (function() {
-            // Configuración - URL del backend
-            const BACKEND_URL = 'http://localhost:8085/motogo/api/v1/auth/verify-email';
+            // Configuración - URL dinámica basada en el hostname de Keycloak
+            // En local: localhost:8080 (Keycloak) → localhost:8085 (API)
+            // En prod: auth.rbsuport.com (Keycloak) → api.rbsuport.com (API)
+            const origin = window.location.origin;
+            const isLocal = origin.includes('localhost') || origin.includes('127.0.0.1');
+            const API_BASE = isLocal 
+                ? 'http://localhost:8085' 
+                : origin.replace('auth.', 'api.');
+            const BACKEND_URL = `${API_BASE}/motogo/api/v1/auth/verify-email`;
             
             // Elementos del DOM
             const loadingState = document.getElementById('loading-state');


### PR DESCRIPTION
## 🚀 Release v0.14.4

### Bug Fixes
- **Keycloak Email Verification** - Fix hardcoded `localhost:8085` backend URL in login theme templates that caused `ERR_CONNECTION_REFUSED` when users clicked the email verification link in production

### Files Changed
- `tools/keycloak-themes/motogo/login/info.ftl` — Dynamic origin-based URL detection (local vs production)
- `tools/keycloak-themes/motogo/email/html/executeActions.ftl` — FreeMarker conditional for local vs production API base URL

### Deployment Notes
After merging, the updated Keycloak theme must be deployed to the VPS:
```bash
docker cp tools/keycloak-themes/motogo keycloak-prod:/opt/keycloak/themes/motogo
docker restart keycloak-prod
```